### PR TITLE
feat: make the hnt function curried

### DIFF
--- a/src/hnt.ts
+++ b/src/hnt.ts
@@ -1,12 +1,14 @@
-export function hnt(array: any[], path: string, fallback: any) {
-  // split the full access path into useable parts
-  // regex for spliting based on . and []
-  const re = /\.|(\[\d+?])/g
-  // use the regex to split the path string
-  // filter to get 'rid' of undefined values
-  const tokens = path.split(re).filter(t => t)
-  // return the data - if the data is undefined return the fallback
-  return conditional(access(array, tokens), fallback)
+export function hnt(array: any[]) {
+  return function hntInner(path: string, fallback: any) {
+    // split the full access path into useable parts
+    // regex for spliting based on . and []
+    const re = /\.|(\[\d+?])/g
+    // use the regex to split the path string
+    // filter to get 'rid' of undefined values
+    const tokens = path.split(re).filter(t => t)
+    // return the data - if the data is undefined return the fallback
+    return conditional(access(array, tokens), fallback)
+  }
 }
 
 function access(arr: any[], tokens: any[]): any {

--- a/test/hnt.test.ts
+++ b/test/hnt.test.ts
@@ -7,15 +7,20 @@ const arr2 = [[[[{ name: "john" }]]]]
 // test the main hnt function
 describe("hnt works", () => {
   it("properly returns deeply nested values", () => {
-    expect(hnt(arr1, "[0].people[0].name", "--")).toEqual("john")
-    expect(hnt(arr2, "[0][0][0]", "--")).toEqual([{ name: "john" }])
+    expect(hnt(arr1)("[0].people[0].name", "--")).toEqual("john")
+    expect(hnt(arr2)("[0][0][0]", "--")).toEqual([{ name: "john" }])
   })
   it("returns a fallback when the path is undefined", () => {
-    expect(hnt(arr1, "people[0]", "--")).toEqual("--")
-    expect(hnt(arr2, "[3]", 3)).toEqual(3)
-    expect(hnt(arr2, "[0][0][1]", [{ name: "john" }])).toEqual([
+    expect(hnt(arr1)("people[0]", "--")).toEqual("--")
+    expect(hnt(arr2)("[3]", 3)).toEqual(3)
+    expect(hnt(arr2)("[0][0][1]", [{ name: "john" }])).toEqual([
       { name: "john" }
     ])
+  })
+  it("curries nicely", () => {
+    const getFromArr1 = hnt(arr1)
+    expect(getFromArr1("[0].people", "--")).toEqual([{ name: "john" }])
+    expect(getFromArr1("[2].people[4].name", "--")).toEqual("--")
   })
 })
 


### PR DESCRIPTION
BREAKING: the usage of the hnt function has changed from:

```js
hnt(array, path, fallback)
```
to 
```js
hnt(array)(path, fallback)
```

This allows things like the following:

```js
let array = [[{ cool: "value" }]]

let getFromArray = hnt(array)

getFromArray("[0][0].cool", "No Value Here!") // value
getFromArray("[100].something", "oops") // oops
```

To Do:

- [ ] Update Documentation to make use of new syntax 
